### PR TITLE
Fix meta_links and cross references in guides and API docs

### DIFF
--- a/content/api-docs/annotorious.md
+++ b/content/api-docs/annotorious.md
@@ -12,7 +12,7 @@ meta_link: "https://annotorious.github.io/api-docs/annotorious"
 
 > The __standard version__ of Annotorious works with normal images embedded in websites
 > or web applications. If you are looking for the Annotorious OpenSeadragon plugin,
-> [see here instead](/annotorious/api-docs/osd-plugin).
+> [see here instead](/api-docs/osd-plugin).
 
 ## Initialization
 
@@ -116,7 +116,7 @@ anno.addAnnotation(annotation [, readOnly]);
 ```
 
 Adds an annotation programmatically. The format is the 
-[W3C WebAnnotation model](/annotorious/getting-started/web-annotation).
+[W3C WebAnnotation model](/getting-started/web-annotation).
 
 | Argument     | Type    | Value                                                                    |
 | ------------ | ------- | ------------------------------------------------------------------------ |

--- a/content/api-docs/osd-plugin.md
+++ b/content/api-docs/osd-plugin.md
@@ -13,7 +13,7 @@ meta_link: "https://annotorious.github.io/api-docs/osd-plugin"
 > The __OpenSeadragon Plugin__ is an extension to the 
 > [OpenSeadragon](http://openseadragon.github.io/) zoomable image viewer. 
 > If you are looking for the standard version of Annotorious, which works with
-> normal images embedded in websites, [see here instead](/annotorious/api-docs/annotorious).
+> normal images embedded in websites, [see here instead](/api-docs/annotorious).
 
 ## Initialization
 

--- a/content/getting-started/_index.md
+++ b/content/getting-started/_index.md
@@ -6,7 +6,7 @@ layout: "section-index"
 include_summaries: false
 meta_title: "Getting Started With Annotorious"
 meta_description: "Examples and instructions for getting started with the Annotorious image annotation library"
-meta_link: "https://recogito.github.io/annotorious/getting-started"
+meta_link: "https://annotorious.github.io/getting-started"
 ---
 
 # Getting Started with Annotorious

--- a/content/getting-started/osd-plugin.md
+++ b/content/getting-started/osd-plugin.md
@@ -8,7 +8,7 @@ blurb: "The __OpenSeadragon plugin__ is an extension to the [OpenSeadragon](http
 weight: 2
 meta_title: "Getting Started With Annotorious OpenSeadragon"
 meta_description: "Examples and instructions for getting started with the Annotorious OpenSeadragon plugin for image annotation"
-meta_link: "https://recogito.github.io/annotorious/getting-started/osd-plugin"
+meta_link: "https://annotorious.github.io/getting-started/osd-plugin"
 ---
 
 # Getting Started with the OpenSeadragon Plugin
@@ -70,7 +70,7 @@ Create the viewer and initialize the Annotorious plugin.
 </script>
 ```
 
-The plugin takes a config object as optional second argument. See the [API Reference](/annotorious/api-docs/osd-plugin/) for details.
+The plugin takes a config object as optional second argument. See the [API Reference](/api-docs/osd-plugin/) for details.
 
 ```javascript
 var anno = OpenSeadragon.Annotorious(viewer, config);

--- a/content/getting-started/storing-annotations.md
+++ b/content/getting-started/storing-annotations.md
@@ -8,14 +8,14 @@ blurb: "To store annotations, you need an annotation server. __Annotorious does 
 weight: 4
 meta_title: "Getting Started: Storing Annotations"
 meta_description: "Learn how you can use the Annotorious JavaScript API to integrate a storage backend"
-meta_link: "https://recogito.github.io/annotorious/getting-started/storing-annotations"
+meta_link: "https://annotorious.github.io/getting-started/storing-annotations"
 ---
 
 # Storing Annotations
 
 __Important:__ Annotorious does not provide a backend for storing annotations online. It provides 
 __user interface functionality only__. To store annotations, you need to connect them to your own 
-backend, using the [JavaScript API](/annotorious/api-docs/).
+backend, using the [JavaScript API](/api-docs/).
 
 When users create, update or delete annotations, Annotorious emits the following events:
 
@@ -37,4 +37,4 @@ anno.on('createAnnotation', function(annotation) {
 ## Using Cloud Storage Services
 
 If you don't want to run your own application backend, cloud storage services offer a good alternative.
-See [our Google Firebase storage plugin](https://recogito.github.io/guides/using-firebase-for-storage/) for a free & personal annotation store solution.
+See [our Google Firebase storage plugin](/guides/using-firebase-for-storage/) for a free & personal annotation store solution.

--- a/content/getting-started/web-annotation.md
+++ b/content/getting-started/web-annotation.md
@@ -8,7 +8,7 @@ blurb: "Annotorious uses the [W3C Web Annotation model](https://www.w3.org/TR/an
 weight: 3
 meta_title: "Annotorious & Web Annotation"
 meta_description: "Learn the basics of how Annotorious uses the W3C Web Annotation standard"
-meta_link: "https://recogito.github.io/annotorious/getting-started/web-annotation"
+meta_link: "https://annotorious.github.io/getting-started/web-annotation"
 ---
 
 # The W3C Web Annotation Model 

--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -6,7 +6,7 @@ layout: "section-index"
 include_summaries: true
 meta_title: "Guides"
 meta_description: "Guides, recipes and examples around Annotorious and RecogitoJS"
-meta_link: "https://recogito.github.io/guides"
+meta_link: "https://annotorious.github.io/guides"
 ---
 
 # Guides

--- a/content/guides/annotorious-in-react.md
+++ b/content/guides/annotorious-in-react.md
@@ -8,7 +8,7 @@ blurb: "A how-to that explains how you can use Annotorious in a React applicatio
 weight: 4
 meta_title: "Annotorious in React"
 meta_description: "A how-to that explains how you can use Annotorious in a React application."
-meta_link: "https://recogito.github.io/guides/annotorious-in-react"
+meta_link: "https://annotorious.github.io/guides/annotorious-in-react"
 ---
 
 # Using Annotorious in React

--- a/content/guides/annotorious-in-vue.md
+++ b/content/guides/annotorious-in-vue.md
@@ -8,7 +8,7 @@ blurb: "A code example that shows how to use Annotorious in a Vue application."
 weight: 4
 meta_title: "Annotorious in Vue"
 meta_description: "A code example that shows how to use Annotorious in Vue.js"
-meta_link: "https://recogito.github.io/guides/annotorious-in-vue"
+meta_link: "https://annotorious.github.io/guides/annotorious-in-vue"
 ---
 
 # Using Annotorious in Vue.js

--- a/content/guides/configuring-the-editor.md
+++ b/content/guides/configuring-the-editor.md
@@ -8,7 +8,7 @@ blurb: "This guide explains how you can configure the widgets that appear in the
 weight: 1
 meta_title: "Configuring the Annotorious/RecogitoJS editor"
 meta_description: "This guide explains how you can configure the widgets that appear in the editor, and how you can pass additional configuration options to specific widgets."
-meta_link: "https://recogito.github.io/guides/configuring-the-editor"
+meta_link: "https://annotorious.github.io/guides/configuring-the-editor"
 ---
 
 # Customizing the Editor

--- a/content/guides/contributing-ui-translations.md
+++ b/content/guides/contributing-ui-translations.md
@@ -8,7 +8,7 @@ blurb: "We want to make the user interface available in as many languages as pos
 weight: 98
 meta_title: "Contributing UI Translations"
 meta_description: "We want to make the user interface available in as many languages as possible. If you want to help: contributing a translation is easy. This guide explains how"
-meta_link: "https://recogito.github.io/guides/contributing-ui-translations"
+meta_link: "https://annotorious.github.io/guides/contributing-ui-translations"
 ---
 
 # Contributing UI Translations

--- a/content/guides/customizing-styles.md
+++ b/content/guides/customizing-styles.md
@@ -8,7 +8,7 @@ blurb: "This guide explains how you can customize the visual appearance of Annot
 weight: 2
 meta_title: "Customizing Annotorious Styles"
 meta_description: "This guide explains how you can customize the visual appearance of Annotorious with CSS."
-meta_link: "https://recogito.github.io/guides/customizing-styles"
+meta_link: "https://annotorious.github.io/guides/customizing-styles"
 ---
 
 # Customizing Visual Appearance

--- a/content/guides/editor-widgets.md
+++ b/content/guides/editor-widgets.md
@@ -8,7 +8,7 @@ blurb: "This guide explains how you can write your own widgets and plug them int
 weight: 6
 meta_title: "Writing Editor Widgets"
 meta_description: "This guide explains how you can write your own widgets and plug them into the annotation editor."
-meta_link: "https://recogito.github.io/guides/editor-widgets"
+meta_link: "https://annotorious.github.io/guides/editor-widgets"
 ---
 
 # Writing Your Own Editor Widgets

--- a/content/guides/editor-widgets.md
+++ b/content/guides/editor-widgets.md
@@ -21,7 +21,7 @@ You can extend the editor with your own __widgets__. A widget can be:
    same interface conventions as the built-in widgets.
 
 > Before you start writing your own widgets, you should first familiarize yourself with the
-> the [W3C Web Annotation specification](/annotorious/getting-started/web-annotation), in 
+> the [W3C Web Annotation specification](/getting-started/web-annotation), in 
 > particular the concepts of __annotation bodies__ and body __purposes__.
 
 ## Annotation Bodies
@@ -148,7 +148,7 @@ Here's what the code does, explained step by step:
 5. Just add a bit of CSS for style
 
 Since the `highlighting` body is now stored in the annotation, we can write a 
-[formatter](/annotorious/api-docs/annotorious/#formatters) that renders highlighted 
+[formatter](/api-docs/annotorious/#formatters) that renders highlighted 
 annotations in different colors. 
 
 ```js

--- a/content/guides/example-react-widget.md
+++ b/content/guides/example-react-widget.md
@@ -8,7 +8,7 @@ blurb: "This guide re-implements the example widget from the previous guide in R
 weight: 7
 meta_title: "Example React Widget"
 meta_description: "An example Annotorious/RecogitoJS editor widget built with React."
-meta_link: "https://recogito.github.io/guides/example-react-widget"
+meta_link: "https://annotorious.github.io/guides/example-react-widget"
 ---
 
 # An Example React Editor Widget

--- a/content/guides/hackers-guide.md
+++ b/content/guides/hackers-guide.md
@@ -8,7 +8,7 @@ blurb: "We welcome contributions! Both to our code as well as our documentation.
 weight: 99
 meta_title: "Annotorious/RecogitoJS Development Setup"
 meta_description: "This guide explains how to set up your development environment for hacking Annotorious or RecogitoJS."
-meta_link: "https://recogito.github.io/guides/hackers-guide"
+meta_link: "https://annotorious.github.io/guides/hackers-guide"
 ---
 
 # Hacker's Guide to Annotorious and RecogitoJS

--- a/content/guides/headless-mode.md
+++ b/content/guides/headless-mode.md
@@ -8,7 +8,7 @@ blurb: "A guide to Headless Mode, which allows you to use Annotorious without th
 weight: 3
 meta_title: "Using Headless Mode"
 meta_description: "A guide to Headless Mode, which allows you to use Annotorious without the editor popup."
-meta_link: "https://recogito.github.io/guides/using-headless-mode"
+meta_link: "https://annotorious.github.io/guides/using-headless-mode"
 ---
 
 # Headless Mode: Using Annotorious without the Editor Popup

--- a/content/guides/headless-mode.md
+++ b/content/guides/headless-mode.md
@@ -20,7 +20,7 @@ lifecycle events. But you are free to build your own user interface, without bei
 forced to the standard editor popup.  
 
 The demo uses headless mode to create annotations with either an __Orange__
-or __Green__ tag, and a [formatter](/annotorious/api-docs/annotorious/#formatters)
+or __Green__ tag, and a [formatter](/api-docs/annotorious/#formatters)
 to color the shapes. (To delete an annotation, select it and press the __Delete__ key.)
 
 {{< inline-headless-demo >}}

--- a/content/guides/using-firebase-for-storage.md
+++ b/content/guides/using-firebase-for-storage.md
@@ -8,7 +8,7 @@ blurb: "In order to store annotations, you need a server backend that is able to
 weight: 5
 meta_title: "Firebase Storage Plugin"
 meta_description: "This guide provides a simple recipe for using Firebase, an online cloud storage service by Google, as your personal annotation server"
-meta_link: "https://recogito.github.io/guides/using-firebase-for-storage"
+meta_link: "https://annotorious.github.io/guides/using-firebase-for-storage"
 ---
 
 # Using Firebase for Storage


### PR DESCRIPTION
Since the Annotorious docs are no longer hosted on the Recogito GitHub subdomain, some URLs needed to be updated.

This PR updates the `meta_link`s in the YAML frontmatter, removes `/annotorious` from relative hrefs and updates other links where necessary.